### PR TITLE
Added support for linting UFT-8 encoded files with BOM

### DIFF
--- a/lib/jslint/vendor/jslint.js
+++ b/lib/jslint/vendor/jslint.js
@@ -5853,6 +5853,12 @@ loop:   for (;;) {
         return amount + " " + word + ((amount == 1) ? "" : "s");
     }
 
+    function removeUTF8BOM(fileContent) {
+        return fileContent.slice(0, 3) === "\u00EF\u00BB\u00BF" ?
+                fileContent.slice(3) :
+                fileContent;
+    }
+
     // parse options from a comma-separated string into a hash
     var optionFields = args[0].split("&");
     var options = {};
@@ -5874,7 +5880,7 @@ loop:   for (;;) {
     for (var f = 1; f < args.length; f++) {
         java.lang.System.out.print("checking " + args[f] + "... ");
 
-        var input = readFile(args[f]);
+        var input = removeUTF8BOM(readFile(args[f]));
         if (!input) {
             print("Error: couldn't open file.");
         } else {


### PR DESCRIPTION
Hi,
all my JavaScript files are encoded in UTF-8 with BOM. So I thought this might be useful for others, too.
Simon
