### PR TITLE
Ensure jslint_on_rails doesn't always create a new default config file

### DIFF
--- a/lib/jslint/rails.rb
+++ b/lib/jslint/rails.rb
@@ -1,4 +1,8 @@
 require 'jslint/utils'
 
 # for Rails, set config file path to config/jslint.yml in Rails root
-JSLint.config_path = File.join(Rails.root, 'config', 'jslint.yml')
+if !JSLint.config_path.nil?
+  fail "JSLint config path #{JSLint.config_path} doesn't exist" if !File.exists?(JSLint.config_path)
+else
+  JSLint.config_path = File.join(Rails.root, 'config', 'jslint.yml')
+end


### PR DESCRIPTION
This change ensures jslint_on_rails doesn't create a new config file in the default location if the config path has already been set to be read from somewhere else for this run.

eg

JSLint.config_path = "otherconfig/jslint-foo.yml"
require 'jslint/tasks'
