### PR TITLE
Escape "on" key to avoid boolean interpretation by yaml

### DIFF
--- a/lib/jslint/config/jslint.yml
+++ b/lib/jslint/config/jslint.yml
@@ -41,7 +41,7 @@ evil:     false     # true if eval should be allowed
 forin:    true      # true if unfiltered 'for in' statements should be allowed
 fragment: true      # true if HTML fragments should be allowed
 laxbreak: false     # true if statement breaks should not be checked
-on:       false     # true if HTML event handlers (e.g. onclick="...") should be allowed
+"on":     false     # true if HTML event handlers (e.g. onclick="...") should be allowed
 sub:      false     # true if subscript notation may be used for expressions better expressed in dot notation
 
 # other options


### PR DESCRIPTION
YAML.load would produce "true=>false" given "on: false".
MultiJson.dump would then (depending on the JSON back-end)
either throw an error ("true is not a valid key"), or pass
a nonsensical "'true':false" option to jslint.
